### PR TITLE
Add the ability to log to stdout.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,4 +2,4 @@ FROM python:3.6-stretch
 RUN git clone https://github.com/Aurorastation/BOREALISbot2.git /app
 WORKDIR /app
 RUN pip install -r requirements.txt
-CMD ["python", "main.py"]
+CMD ["python", "main.py", "--no-log-file", "--log-console"]

--- a/cogs/silly.py
+++ b/cogs/silly.py
@@ -103,7 +103,7 @@ class SillyCog:
     @commands.command()
     @auth.check_auths([AuthPerms.R_ADMIN])
     async def memetype(self, ctx, *args):
-        """They hate him for many things. But specialyl for this."""
+        """They hate him for many things. But specially for this."""
         msg = []
 
         for word in args:


### PR DESCRIPTION
Adds the ability for the bot to log to stdout and disable logging to logfiles.
If its running in a docker container, logging to a logfile is not really a practical solution.
Therefore I added two commandline switches that can be used to enable/disable logging to file/console respectively.
Without the switches the bot behaves like it does right now (logging only to the logfile)
The Dockerfile has been updated to only log to the console.

Also fixes a spelling mistake in a description