### PR TITLE
Fixes a issue that prevents strikes from being logged to discord.

### DIFF
--- a/core/bot.py
+++ b/core/bot.py
@@ -56,7 +56,10 @@ class Borealis(commands.Bot):
             if not config:
                 raise BotError("No Config accessible to bot.", "forward_message")
 
-            channel_objs = config.get_channels(channel_str)
+            channel_ids = config.get_channels(channel_str)
+            channel_objs = []
+            for cid in channel_ids:
+                channel_objs.append(self.get_channel(str(cid)))
 
         if not channel_objs or not len(channel_objs):
             return

--- a/core/subsystems/config.py
+++ b/core/subsystems/config.py
@@ -69,17 +69,13 @@ class Config():
                 raise ConfigError("Error reading config: {}".format(err), "setup")
 
     def get_channels(self, channel_group):
-        """Get a list of channel objects that are grouped together."""
+        """Get a list of channel ids that are grouped together. The actual channels still have to be gathered via the bot"""
         self.logger.debug("Config: getting channels from channel group {0}".format(channel_group))
 
         if channel_group not in self.channels:
             return []
 
-        channel_objs = []
-        for cid in self.channels[channel_group]:
-            channel_objs.append(self.bot.get_channel(str(cid)))
-
-        return channel_objs
+        return self.channels[channel_group]
 
     def get_channels_group(self, channel_id):
         out = []


### PR DESCRIPTION
As it sais on the tin.

Issue is that the bot object does not exist in the config object since the refactor to borbor3
This fixes that problem by having the config return a list of channel ids instead of channels.