### PR TITLE
Making things make sense

### DIFF
--- a/cogs/server.py
+++ b/cogs/server.py
@@ -84,6 +84,7 @@ class ServerCog():
         embed.add_field(name="Mode:", value=data["mode"])
         embed.add_field(name="Players:", value=data["players"])
         embed.add_field(name="Staff:", value=data["staff"])
+        embed.add_field(name="Admins:", value=data["admins"])
         await ctx.send(embed=embed)
 
     @commands.command(aliases=["serverrestart", "srestart"])

--- a/cogs/server.py
+++ b/cogs/server.py
@@ -83,7 +83,7 @@ class ServerCog():
         embed.add_field(name="Duration:", value=data["roundduration"])
         embed.add_field(name="Mode:", value=data["mode"])
         embed.add_field(name="Players:", value=data["players"])
-        embed.add_field(name="Admins:", value=data["admins"])
+        embed.add_field(name="Staff:", value=data["staff"])
         await ctx.send(embed=embed)
 
     @commands.command(aliases=["serverrestart", "srestart"])


### PR DESCRIPTION
When you request status from bot, it counts anyone into `Admins` field. Well this PR renames it to `Staff` to avoid confusion.